### PR TITLE
Add JSON-RPC method to enable listening on a VVC

### DIFF
--- a/src/cpp/uvvm_cosim_client.hpp
+++ b/src/cpp/uvvm_cosim_client.hpp
@@ -24,8 +24,8 @@ public:
     return CallMethod<JsonResponse>(requestId++, "GetVvcList", {});
   }
 
-  JsonResponse SetVvcCosimRecvState(std::string vvc_type, int vvc_id, bool enable) {
-    return CallMethod<JsonResponse>(requestId++, "SetVvcCosimRecvState", {vvc_type, vvc_id, enable});
+  JsonResponse SetVvcListenEnable(std::string vvc_type, int vvc_id, bool enable) {
+    return CallMethod<JsonResponse>(requestId++, "SetVvcListenEnable", {vvc_type, vvc_id, enable});
   }
 
   JsonResponse TransmitBytes(std::string vvc_type, int vvc_id, std::vector<uint8_t> data)

--- a/src/cpp/uvvm_cosim_client.hpp
+++ b/src/cpp/uvvm_cosim_client.hpp
@@ -24,6 +24,10 @@ public:
     return CallMethod<JsonResponse>(requestId++, "GetVvcList", {});
   }
 
+  JsonResponse SetVvcCosimRecvState(std::string vvc_type, int vvc_id, bool enable) {
+    return CallMethod<JsonResponse>(requestId++, "SetVvcCosimRecvState", {vvc_type, vvc_id, enable});
+  }
+
   JsonResponse TransmitBytes(std::string vvc_type, int vvc_id, std::vector<uint8_t> data)
   {
     return CallMethod<JsonResponse>(requestId++, "TransmitBytes", {vvc_type, vvc_id, data});

--- a/src/cpp/uvvm_cosim_client_example.cpp
+++ b/src/cpp/uvvm_cosim_client_example.cpp
@@ -42,8 +42,8 @@ void print_vvc(const VvcInstance& vvc)
   for (auto &cfg : vvc.bfm_cfg) {
     std::cout << cfg.first << "=" << cfg.second << " ";
   }
-  std::cout << "Cosim recv enabled: "
-            << (vvc.cosim_recv_enable ? "true" : "false") << std::endl;
+  std::cout << "listen_enable: "
+            << (vvc.listen_enable ? "true" : "false") << std::endl;
 }
 
 void print_vvc_list(const JsonResponse& vvc_list_json)
@@ -84,8 +84,8 @@ int main(int argc, char** argv)
   print_vvc_list(vvc_list);
 
   std::cout << "Enable cosim listening on AXI-S VVC 1 and UART VVC 1" << std::endl;
-  client.SetVvcCosimRecvState("UART_VVC", 1, true);
-  client.SetVvcCosimRecvState("AXISTREAM_VVC", 1, true);
+  client.SetVvcListenEnable("UART_VVC", 1, true);
+  client.SetVvcListenEnable("AXISTREAM_VVC", 1, true);
   std::this_thread::sleep_for(0.5s);
 
   std::cout << "Get VVC list again...." << std::endl << std::endl;

--- a/src/cpp/uvvm_cosim_client_example.cpp
+++ b/src/cpp/uvvm_cosim_client_example.cpp
@@ -8,7 +8,6 @@
 #include "uvvm_cosim_client.hpp"
 #include "uvvm_cosim_types.hpp"
 
-
 void print_received_data(const std::vector<uint8_t>& data)
 {
   std::cout << "data = [";
@@ -33,6 +32,35 @@ void print_receive_result(const JsonResponse& response, const std::string& vvc_n
   }
 }
 
+void print_vvc(const VvcInstance& vvc)
+{
+  std::cout << "Type: " << vvc.vvc_type << ", ";
+  std::cout << "Channel: " << vvc.vvc_channel << ", ";
+  std::cout << "Instance ID: " << vvc.vvc_instance_id << std::endl;
+
+  std::cout << "Config: ";
+  for (auto &cfg : vvc.bfm_cfg) {
+    std::cout << cfg.first << "=" << cfg.second << " ";
+  }
+  std::cout << "Cosim recv enabled: "
+            << (vvc.cosim_recv_enable ? "true" : "false") << std::endl;
+}
+
+void print_vvc_list(const JsonResponse& vvc_list_json)
+{
+  if (vvc_list_json.success && vvc_list_json.result.is_array()) {
+    std::cout << "VVC List:" << std::endl;
+    std::cout << "-----------------------------------------------------" << std::endl;
+    for (auto &vvc_json : vvc_list_json.result) {
+      VvcInstance vvc = vvc_json;
+      print_vvc(vvc);
+      std::cout << std::endl << std::endl;
+    }
+  } else {
+    std::cout << "Failed to get VVC list: " << vvc_list_json.result["error"] << std::endl;
+  }
+}
+
 // Test connecting, transmitting and receiving some bytes
 int main(int argc, char** argv)
 {
@@ -51,29 +79,18 @@ int main(int argc, char** argv)
 
   std::this_thread::sleep_for(0.5s);
 
-  std::cout << "Get VVC list...." << std::endl;
-
+  std::cout << "Get VVC list...." << std::endl << std::endl;
   auto vvc_list = client.GetVvcList();
+  print_vvc_list(vvc_list);
 
-  std::cout << "VVC list response: " << std::endl;
-  std::cout << vvc_list.result.dump(4) << std::endl << std::endl;
+  std::cout << "Enable cosim listening on AXI-S VVC 1 and UART VVC 1" << std::endl;
+  client.SetVvcCosimRecvState("UART_VVC", 1, true);
+  client.SetVvcCosimRecvState("AXISTREAM_VVC", 1, true);
+  std::this_thread::sleep_for(0.5s);
 
-  if (vvc_list.success && vvc_list.result.is_array()) {
-    for (auto &vvc_json : vvc_list.result) {
-      VvcInstance vvc = vvc_json;
-      std::cout << "Type: " << vvc.vvc_type << ", ";
-      std::cout << "Channel: " << vvc.vvc_channel << ", ";
-      std::cout << "Instance ID: " << vvc.vvc_instance_id << std::endl;
-
-      std::cout << "Config: ";
-      for (auto &cfg : vvc.vvc_cfg) {
-        std::cout << cfg.first << "=" << cfg.second << " ";
-      }
-      std::cout << std::endl << std::endl;
-    }
-  } else {
-    std::cout << "Failed to get VVC list: " << vvc_list.result["error"] << std::endl;
-  }
+  std::cout << "Get VVC list again...." << std::endl << std::endl;
+  vvc_list = client.GetVvcList();
+  print_vvc_list(vvc_list);
 
   std::this_thread::sleep_for(0.5s);
 

--- a/src/cpp/uvvm_cosim_server.cpp
+++ b/src/cpp/uvvm_cosim_server.cpp
@@ -72,7 +72,7 @@ UvvmCosimServer::WaitForStartSim()
 }
 
 bool
-UvvmCosimServer::VvcCosimRecvEnabled(std::string vvc_type,
+UvvmCosimServer::VvcListenEnabled(std::string vvc_type,
 				     int vvc_instance_id)
 {
   VvcInstanceKey vvc = {
@@ -83,7 +83,7 @@ UvvmCosimServer::VvcCosimRecvEnabled(std::string vvc_type,
 
   bool listen = vvcInstanceMap([&](auto &vvc_map) {
     if (auto it = vvc_map.find(vvc); it != vvc_map.end()) {
-      return it->second.cfg.cosim_recv_enable;
+      return it->second.cfg.listen_enable;
     } else {
       std::cerr << "VVC with";
       std::cerr << " type=" << vvc.vvc_type;
@@ -245,7 +245,7 @@ UvvmCosimServer::GetVvcList()
 }
 
 JsonResponse
-UvvmCosimServer::SetVvcCosimRecvState(std::string vvc_type, int vvc_id, bool enable)
+UvvmCosimServer::SetVvcListenEnable(std::string vvc_type, int vvc_id, bool enable)
 {
   JsonResponse response;
 
@@ -257,7 +257,7 @@ UvvmCosimServer::SetVvcCosimRecvState(std::string vvc_type, int vvc_id, bool ena
 
   vvcInstanceMap([&](auto &vvc_map) {
     if (decltype(vvc_map.begin()) it = vvc_map.find(vvc); it != vvc_map.end()) {
-      it->second.cfg.cosim_recv_enable = enable;
+      it->second.cfg.listen_enable = enable;
       response.success = true;
       response.result = json{};
 

--- a/src/cpp/uvvm_cosim_server.hpp
+++ b/src/cpp/uvvm_cosim_server.hpp
@@ -29,7 +29,7 @@ private:
 
   JsonResponse StartSim();
   JsonResponse GetVvcList();
-  JsonResponse SetVvcCosimRecvState(std::string vvc_type, int vvc_id, bool enable);
+  JsonResponse SetVvcListenEnable(std::string vvc_type, int vvc_id, bool enable);
 
   JsonResponse TransmitBytes(std::string vvc_type, int vvc_id, std::vector<uint8_t> data);
   JsonResponse TransmitPacket(std::string vvc_type, int vvc_id, std::vector<uint8_t> data);
@@ -65,8 +65,8 @@ public:
     jsonRpcServer.Add("GetVvcList",
                       GetHandle(&UvvmCosimServer::GetVvcList, *this), {});
 
-    jsonRpcServer.Add("SetVvcCosimRecvState",
-                      GetHandle(&UvvmCosimServer::SetVvcCosimRecvState, *this),
+    jsonRpcServer.Add("SetVvcListenEnable",
+                      GetHandle(&UvvmCosimServer::SetVvcListenEnable, *this),
 		      {"vvc_type", "vvc_id", "enable"});
 
     jsonRpcServer.Add("StartSim",
@@ -94,7 +94,7 @@ public:
 
   void WaitForStartSim();
 
-  bool VvcCosimRecvEnabled(std::string vvc_type,
+  bool VvcListenEnabled(std::string vvc_type,
 			   int vvc_instance_id);
 
   void AddVvc(std::string vvc_type, std::string vvc_channel,

--- a/src/cpp/uvvm_cosim_server.hpp
+++ b/src/cpp/uvvm_cosim_server.hpp
@@ -16,10 +16,10 @@ private:
   jsonrpccxx::JsonRpc2Server jsonRpcServer;
   CppHttpLibServerConnector httpServer;
 
-  // Key type: VvcInstance
-  // Value type: VvcQueues
-  // Comparator: VvcCompare
-  shared_map<VvcInstance, VvcQueues, VvcCompare> vvcInstanceMap;
+  // VvcInstanceKey: Identifies VVC by type, channel, id
+  // VvcInstanceData: Transmit+receive queue for VVC, config, etc.
+  // VvcCompare: Comparator class for VvcInstanceKey
+  shared_map<VvcInstanceKey, VvcInstanceData, VvcCompare> vvcInstanceMap;
 
   std::atomic<bool> startSim=false;
 
@@ -29,7 +29,7 @@ private:
 
   JsonResponse StartSim();
   JsonResponse GetVvcList();
-  JsonResponse SetVvcListen(std::string vvc_type, int vvc_id, bool listen_enable);
+  JsonResponse SetVvcCosimRecvState(std::string vvc_type, int vvc_id, bool enable);
 
   JsonResponse TransmitBytes(std::string vvc_type, int vvc_id, std::vector<uint8_t> data);
   JsonResponse TransmitPacket(std::string vvc_type, int vvc_id, std::vector<uint8_t> data);
@@ -65,9 +65,9 @@ public:
     jsonRpcServer.Add("GetVvcList",
                       GetHandle(&UvvmCosimServer::GetVvcList, *this), {});
 
-    jsonRpcServer.Add("SetVvcListen",
-                      GetHandle(&UvvmCosimServer::SetVvcListen, *this),
-		      {"vvc_type", "vvc_id", "listen_enable"});
+    jsonRpcServer.Add("SetVvcCosimRecvState",
+                      GetHandle(&UvvmCosimServer::SetVvcCosimRecvState, *this),
+		      {"vvc_type", "vvc_id", "enable"});
 
     jsonRpcServer.Add("StartSim",
 		      GetHandle(&UvvmCosimServer::StartSim, *this), {});
@@ -94,11 +94,11 @@ public:
 
   void WaitForStartSim();
 
-  bool VvcListenEnabled(std::string vvc_type,
-			int vvc_instance_id);
+  bool VvcCosimRecvEnabled(std::string vvc_type,
+			   int vvc_instance_id);
 
   void AddVvc(std::string vvc_type, std::string vvc_channel,
-	      int vvc_instance_id, std::string vvc_cfg_str);
+	      int vvc_instance_id, std::string bfm_cfg_str);
 
   bool TransmitQueueEmpty(std::string vvc_type, int vvc_instance_id);
 

--- a/src/cpp/uvvm_cosim_server.hpp
+++ b/src/cpp/uvvm_cosim_server.hpp
@@ -29,6 +29,7 @@ private:
 
   JsonResponse StartSim();
   JsonResponse GetVvcList();
+  JsonResponse SetVvcListen(std::string vvc_type, int vvc_id, bool listen_enable);
 
   JsonResponse TransmitBytes(std::string vvc_type, int vvc_id, std::vector<uint8_t> data);
   JsonResponse TransmitPacket(std::string vvc_type, int vvc_id, std::vector<uint8_t> data);
@@ -64,6 +65,10 @@ public:
     jsonRpcServer.Add("GetVvcList",
                       GetHandle(&UvvmCosimServer::GetVvcList, *this), {});
 
+    jsonRpcServer.Add("SetVvcListen",
+                      GetHandle(&UvvmCosimServer::SetVvcListen, *this),
+		      {"vvc_type", "vvc_id", "listen_enable"});
+
     jsonRpcServer.Add("StartSim",
 		      GetHandle(&UvvmCosimServer::StartSim, *this), {});
   }
@@ -88,6 +93,9 @@ public:
   }
 
   void WaitForStartSim();
+
+  bool VvcListenEnabled(std::string vvc_type,
+			int vvc_instance_id);
 
   void AddVvc(std::string vvc_type, std::string vvc_channel,
 	      int vvc_instance_id, std::string vvc_cfg_str);

--- a/src/cpp/uvvm_cosim_types.hpp
+++ b/src/cpp/uvvm_cosim_types.hpp
@@ -15,11 +15,19 @@ struct VvcQueues {
   std::deque<std::pair<uint8_t, bool>> receive_queue;
 };
 
+// Todo:
+// It's pretty dumb to store data in the key
+// (VvcInstance is used as key in std::map of VVCs).
+// Should replace with a VvcInstanceKey class that has only
+// vvc_type, vvc_channel, and vvc_id.
+// And then put the queues from VvcQueues, vvc_cfg, listen_enable
+// (and any future fields) in VvcInstance class.
 struct VvcInstance {
   std::string vvc_type;
   std::string vvc_channel;
   int vvc_instance_id;
   std::map<std::string, int> vvc_cfg;
+  bool listen_enable = false;
 };
 
 // This class should implement the necessary comparator function (with

--- a/src/cpp/uvvm_cosim_types.hpp
+++ b/src/cpp/uvvm_cosim_types.hpp
@@ -9,35 +9,42 @@
 
 using json = nlohmann::json;
 
-// Note: Many VVCs will only use one of the queues
-struct VvcQueues {
+// Used as key in std::map of all VVCs in server
+struct VvcInstanceKey {
+  std::string vvc_type;
+  std::string vvc_channel;
+  int vvc_instance_id;
+};
+
+struct VvcConfig {
+  std::map<std::string, int> bfm_cfg;
+  bool cosim_recv_enable = false;
+};
+
+// Used as value in std::map of all VVCs in server
+struct VvcInstanceData {
+  VvcConfig cfg;
+
+  // Note: Many VVCs will only use one of the queues
   std::deque<std::pair<uint8_t, bool>> transmit_queue;
   std::deque<std::pair<uint8_t, bool>> receive_queue;
 };
 
-// Todo:
-// It's pretty dumb to store data in the key
-// (VvcInstance is used as key in std::map of VVCs).
-// Should replace with a VvcInstanceKey class that has only
-// vvc_type, vvc_channel, and vvc_id.
-// And then put the queues from VvcQueues, vvc_cfg, listen_enable
-// (and any future fields) in VvcInstance class.
-struct VvcInstance {
-  std::string vvc_type;
-  std::string vvc_channel;
-  int vvc_instance_id;
-  std::map<std::string, int> vvc_cfg;
-  bool listen_enable = false;
+// This struct contains all fields that identify a VVC as well as
+// configuration values, but not the transmit/receive queues.
+// It's used to send VVC info over JSON-RPC
+struct VvcInstance : public VvcInstanceKey, VvcConfig {
+  VvcInstance() {}
+  VvcInstance(VvcInstanceKey k, VvcConfig c)
+      : VvcInstanceKey(k), VvcConfig(c) {}
 };
 
 // This class should implement the necessary comparator function (with
-// strict ordering) so we can use VvcInstance with std::map.
+// strict ordering) so we can use VvcInstanceKey with std::map.
 // https://stackoverflow.com/questions/6573225/what-requirements-must-stdmap-key-classes-meet-to-be-valid-keys
-// Note that we don't care about vvc_cfg, just want to be able to
-// distinguish between VVCs based on type, channel, and ID.
 class VvcCompare {
 public:
-  bool operator() (const VvcInstance &lhs, const VvcInstance &rhs) const {
+  bool operator() (const VvcInstanceKey &lhs, const VvcInstanceKey &rhs) const {
     if (lhs.vvc_type < rhs.vvc_type) return true;
     if (lhs.vvc_type > rhs.vvc_type) return false;
     if (lhs.vvc_channel < rhs.vvc_channel) return true;
@@ -51,14 +58,16 @@ inline void to_json(json &j, const VvcInstance &v) {
   j = json{{"vvc_type", v.vvc_type},
            {"vvc_channel", v.vvc_channel},
            {"vvc_instance_id", v.vvc_instance_id},
-           {"vvc_cfg", v.vvc_cfg}};
+           {"bfm_cfg", v.bfm_cfg},
+           {"cosim_recv_enable", v.cosim_recv_enable}};
 }
 
 inline void from_json(const json &j, VvcInstance &v) {
   j.at("vvc_type").get_to(v.vvc_type);
   j.at("vvc_channel").get_to(v.vvc_channel);
   j.at("vvc_instance_id").get_to(v.vvc_instance_id);
-  j.at("vvc_cfg").get_to(v.vvc_cfg);
+  j.at("bfm_cfg").get_to(v.bfm_cfg);
+  j.at("cosim_recv_enable").get_to(v.cosim_recv_enable);
 }
 
 struct JsonResponse {

--- a/src/cpp/uvvm_cosim_types.hpp
+++ b/src/cpp/uvvm_cosim_types.hpp
@@ -18,7 +18,7 @@ struct VvcInstanceKey {
 
 struct VvcConfig {
   std::map<std::string, int> bfm_cfg;
-  bool cosim_recv_enable = false;
+  bool listen_enable = false;
 };
 
 // Used as value in std::map of all VVCs in server
@@ -59,7 +59,7 @@ inline void to_json(json &j, const VvcInstance &v) {
            {"vvc_channel", v.vvc_channel},
            {"vvc_instance_id", v.vvc_instance_id},
            {"bfm_cfg", v.bfm_cfg},
-           {"cosim_recv_enable", v.cosim_recv_enable}};
+           {"listen_enable", v.listen_enable}};
 }
 
 inline void from_json(const json &j, VvcInstance &v) {
@@ -67,7 +67,7 @@ inline void from_json(const json &j, VvcInstance &v) {
   j.at("vvc_channel").get_to(v.vvc_channel);
   j.at("vvc_instance_id").get_to(v.vvc_instance_id);
   j.at("bfm_cfg").get_to(v.bfm_cfg);
-  j.at("cosim_recv_enable").get_to(v.cosim_recv_enable);
+  j.at("listen_enable").get_to(v.listen_enable);
 }
 
 struct JsonResponse {

--- a/src/cpp/uvvm_cosim_vhpi.cpp
+++ b/src/cpp/uvvm_cosim_vhpi.cpp
@@ -97,7 +97,7 @@ void vhpi_cosim_listen_enable(const vhpiCbDataT* p_cb_data)
   std::string vvc_type = get_vhpi_cb_string_param_by_index(p_cb_data, 0);
   int vvc_instance_id = get_vhpi_cb_int_param_by_index(p_cb_data, 1);
 
-  bool listen = cosim_server->VvcCosimRecvEnabled(vvc_type, vvc_instance_id);
+  bool listen = cosim_server->VvcListenEnabled(vvc_type, vvc_instance_id);
 
   set_vhpi_int_retval(p_cb_data, listen ? 1 : 0);
 }

--- a/src/cpp/uvvm_cosim_vhpi.cpp
+++ b/src/cpp/uvvm_cosim_vhpi.cpp
@@ -95,10 +95,9 @@ void vhpi_cosim_start_sim(const vhpiCbDataT* p_cb_data)
 void vhpi_cosim_listen_enable(const vhpiCbDataT* p_cb_data)
 {
   std::string vvc_type = get_vhpi_cb_string_param_by_index(p_cb_data, 0);
-  std::string vvc_channel = get_vhpi_cb_string_param_by_index(p_cb_data, 1);
-  int vvc_instance_id = get_vhpi_cb_int_param_by_index(p_cb_data, 2);
+  int vvc_instance_id = get_vhpi_cb_int_param_by_index(p_cb_data, 1);
 
-  bool listen = cosim_server->VvcListenEnabled(vvc_type, vvc_channel, vvc_instance_id);
+  bool listen = cosim_server->VvcCosimRecvEnabled(vvc_type, vvc_instance_id);
 
   set_vhpi_int_retval(p_cb_data, listen ? 1 : 0);
 }
@@ -108,16 +107,16 @@ void vhpi_cosim_report_vvc_info(const vhpiCbDataT* p_cb_data)
   std::string vvc_type = get_vhpi_cb_string_param_by_index(p_cb_data, 0);
   std::string vvc_channel = get_vhpi_cb_string_param_by_index(p_cb_data, 1);
   int vvc_instance_id = get_vhpi_cb_int_param_by_index(p_cb_data, 2);
-  std::string vvc_cfg_str = get_vhpi_cb_string_param_by_index(p_cb_data, 3);
+  std::string bfm_cfg_str = get_vhpi_cb_string_param_by_index(p_cb_data, 3);
 
   vhpi_printf("vhpi_cosim_report_vvc_info: Got:");
   vhpi_printf("Type=%s, Channel=%s, ID=%d, cfg=%s",
 	      vvc_type.c_str(),
 	      vvc_channel.c_str(),
 	      vvc_instance_id,
-	      vvc_cfg_str.c_str());
+	      bfm_cfg_str.c_str());
 
-  cosim_server->AddVvc(vvc_type, vvc_channel, vvc_instance_id, vvc_cfg_str);
+  cosim_server->AddVvc(vvc_type, vvc_channel, vvc_instance_id, bfm_cfg_str);
 }
 
 long convert_time_to_ns(const vhpiTimeT *time)

--- a/src/cpp/uvvm_cosim_vhpi.cpp
+++ b/src/cpp/uvvm_cosim_vhpi.cpp
@@ -92,6 +92,17 @@ void vhpi_cosim_start_sim(const vhpiCbDataT* p_cb_data)
   vhpi_printf("vhpi_cosim_start_sim: Starting sim");
 }
 
+void vhpi_cosim_listen_enable(const vhpiCbDataT* p_cb_data)
+{
+  std::string vvc_type = get_vhpi_cb_string_param_by_index(p_cb_data, 0);
+  std::string vvc_channel = get_vhpi_cb_string_param_by_index(p_cb_data, 1);
+  int vvc_instance_id = get_vhpi_cb_int_param_by_index(p_cb_data, 2);
+
+  bool listen = cosim_server->VvcListenEnabled(vvc_type, vvc_channel, vvc_instance_id);
+
+  set_vhpi_int_retval(p_cb_data, listen ? 1 : 0);
+}
+
 void vhpi_cosim_report_vvc_info(const vhpiCbDataT* p_cb_data)
 {
   std::string vvc_type = get_vhpi_cb_string_param_by_index(p_cb_data, 0);
@@ -144,6 +155,11 @@ void startup_register_foreign_methods(void)
 			       "vhpi_cosim_start_sim",
 			       c_lib_name,
 			       vhpiProcF);
+
+  register_vhpi_foreign_method(vhpi_cosim_listen_enable,
+			       "vhpi_cosim_listen_enable",
+			       c_lib_name,
+			       vhpiFuncF);
 
   register_vhpi_foreign_method(vhpi_cosim_transmit_queue_empty,
 			       "vhpi_cosim_transmit_queue_empty",

--- a/src/python/example_client_requests-lib.py
+++ b/src/python/example_client_requests-lib.py
@@ -1,3 +1,4 @@
+import itertools
 import requests
 import time
 
@@ -5,11 +6,13 @@ import time
 def main():
     url = "http://localhost:8484/jsonrpc"
 
+    id = itertools.count(start=0, step=1)
+
     payload = {
         "method": "StartSim",
         "params": [],
         "jsonrpc": "2.0",
-        "id": 0,
+        "id": next(id),
     }
     requests.post(url, json=payload).json()
 
@@ -19,11 +22,35 @@ def main():
         "method": "GetVvcList",
         "params": [],
         "jsonrpc": "2.0",
-        "id": 1,
+        "id": next(id),
     }
     response = requests.post(url, json=payload).json()
     print(f"request = {payload}")
     print(f"VVC list response: {response}")
+
+    print("")
+    print("Enable listening on UART_VVC 1 and AXISTREAM_VVC 1")
+    payload = {
+        "method": "SetVvcCosimRecvState",
+        "params": {"vvc_type": "UART_VVC",
+                   "vvc_id": 1,
+                   "enable": True},
+        "jsonrpc": "2.0",
+        "id": next(id),
+    }
+    requests.post(url, json=payload).json()
+
+    payload = {
+        "method": "SetVvcCosimRecvState",
+        "params": {"vvc_type": "UART_VVC",
+                   "vvc_id": 1,
+                   "enable": True},
+        "jsonrpc": "2.0",
+        "id": next(id),
+    }
+    requests.post(url, json=payload).json()
+
+    time.sleep(0.5)
 
     payload = {
         "method": "TransmitBytes",
@@ -31,7 +58,7 @@ def main():
                    "vvc_id": 0,
                    "data": [10, 20, 30, 40, 50]},
         "jsonrpc": "2.0",
-        "id": 2,
+        "id": next(id),
     }
     response = requests.post(url, json=payload).json()
     print(f"request = {payload}")
@@ -46,7 +73,7 @@ def main():
                    "length": 5,
                    "all_or_nothing": False},
         "jsonrpc": "2.0",
-        "id": 3,
+        "id": next(id),
     }
     response = requests.post(url, json=payload).json()
     print(f"request = {payload}")

--- a/src/python/example_client_requests-lib.py
+++ b/src/python/example_client_requests-lib.py
@@ -31,7 +31,7 @@ def main():
     print("")
     print("Enable listening on UART_VVC 1 and AXISTREAM_VVC 1")
     payload = {
-        "method": "SetVvcCosimRecvState",
+        "method": "SetVvcListenEnable",
         "params": {"vvc_type": "UART_VVC",
                    "vvc_id": 1,
                    "enable": True},
@@ -41,7 +41,7 @@ def main():
     requests.post(url, json=payload).json()
 
     payload = {
-        "method": "SetVvcCosimRecvState",
+        "method": "SetVvcListenEnable",
         "params": {"vvc_type": "UART_VVC",
                    "vvc_id": 1,
                    "enable": True},

--- a/src/python/example_client_tinyrpc-lib.py
+++ b/src/python/example_client_tinyrpc-lib.py
@@ -16,6 +16,20 @@ def main():
     response = rpc_client.call(method="GetVvcList", args=None, kwargs=None)
     print(f"VVC list response: {response}")
 
+    response = rpc_client.call(method="SetVvcCosimRecvState", args=None,
+                               kwargs={"vvc_type": "UART_VVC",
+                                       "vvc_id": 1,
+                                       "enable": True},
+                               one_way=False)
+
+    response = rpc_client.call(method="SetVvcCosimRecvState", args=None,
+                               kwargs={"vvc_type": "AXISTREAM_VVC",
+                                       "vvc_id": 1,
+                                       "enable": True},
+                               one_way=False)
+
+    time.sleep(0.5)
+
     response = rpc_client.call(method="TransmitBytes", args=None,
                                kwargs={"vvc_type": "UART_VVC",
                                        "vvc_id": 0,

--- a/src/python/example_client_tinyrpc-lib.py
+++ b/src/python/example_client_tinyrpc-lib.py
@@ -16,13 +16,13 @@ def main():
     response = rpc_client.call(method="GetVvcList", args=None, kwargs=None)
     print(f"VVC list response: {response}")
 
-    response = rpc_client.call(method="SetVvcCosimRecvState", args=None,
+    response = rpc_client.call(method="SetVvcListenEnable", args=None,
                                kwargs={"vvc_type": "UART_VVC",
                                        "vvc_id": 1,
                                        "enable": True},
                                one_way=False)
 
-    response = rpc_client.call(method="SetVvcCosimRecvState", args=None,
+    response = rpc_client.call(method="SetVvcListenEnable", args=None,
                                kwargs={"vvc_type": "AXISTREAM_VVC",
                                        "vvc_id": 1,
                                        "enable": True},

--- a/src/vhdl/uvvm_cosim.vhd
+++ b/src/vhdl/uvvm_cosim.vhd
@@ -43,7 +43,7 @@ begin
   p_uvvm_cosim_init : process
     variable vvc_channel     : t_channel;
     variable vvc_instance_id : integer;
-    variable vvc_cfg         : line :=  null;
+    variable bfm_cfg         : line :=  null;
   begin
 
     await_uvvm_initialization(VOID);
@@ -82,17 +82,17 @@ begin
         end if;
 
         -- Comma-separated string with VVC config
-        vvc_cfg := bfm_cfg_to_string(shared_uart_vvc_config(vvc_channel, vvc_instance_id).bfm_config);
+        bfm_cfg := bfm_cfg_to_string(shared_uart_vvc_config(vvc_channel, vvc_instance_id).bfm_config);
 
       elsif strcmp("AXISTREAM_VVC", shared_vvc_activity_register.priv_get_vvc_name(idx)) then
         -- Mark instance id as in use
         axis_vvc_indexes_in_use(vvc_instance_id) <= '1';
 
         -- Comma-separated string with VVC config
-        vvc_cfg := bfm_cfg_to_string(shared_axistream_vvc_config(vvc_instance_id).bfm_config);
+        bfm_cfg := bfm_cfg_to_string(shared_axistream_vvc_config(vvc_instance_id).bfm_config);
       else
         -- Unsupported VVC
-        vvc_cfg := bfm_cfg_to_string(VOID);
+        bfm_cfg := bfm_cfg_to_string(VOID);
       end if;
 
       -- Todo:
@@ -103,10 +103,10 @@ begin
         shared_vvc_activity_register.priv_get_vvc_name(idx),
         to_string(vvc_channel),
         vvc_instance_id,
-        vvc_cfg.all
+        bfm_cfg.all
         );
 
-      deallocate(vvc_cfg);
+      deallocate(bfm_cfg);
 
     end loop;
 

--- a/src/vhdl/uvvm_cosim.vhd
+++ b/src/vhdl/uvvm_cosim.vhd
@@ -56,6 +56,9 @@ begin
       vhpi_cosim_start_sim; -- Blocks until user says sim should start
 
       log(ID_SEQUENCER, "Starting simulation", C_SCOPE);
+    else
+      -- Co-sim disabled
+      wait;
     end if;
 
     -- Check which VVCs were registered in this testbench

--- a/src/vhdl/uvvm_cosim_axis_vvc_ctrl.vhd
+++ b/src/vhdl/uvvm_cosim_axis_vvc_ctrl.vhd
@@ -117,7 +117,7 @@ begin
 
     function listen_enable (void : t_void) return boolean is
     begin
-      if vhpi_cosim_vvc_listen_enable("AXISTREAM_VVC", "NA", GC_VVC_IDX) then
+      if vhpi_cosim_vvc_listen_enable("AXISTREAM_VVC", GC_VVC_IDX) then
         return true;
       else
         return false;

--- a/src/vhdl/uvvm_cosim_axis_vvc_ctrl.vhd
+++ b/src/vhdl/uvvm_cosim_axis_vvc_ctrl.vhd
@@ -130,9 +130,9 @@ begin
         alert(TB_ERROR, "AXISTREAM VVC " & to_string(GC_VVC_IDX) & ": Max wait cycles severity (timeout) should be set to NO_ALERT for cosim", C_SCOPE);
       end if;
 
-        if bfm_config.check_packet_length then
-          alert(TB_ERROR, "AXISTREAM VVC = " & to_string(GC_VVC_IDX) & ": Packet length (tlast) is not supported for cosim yet", C_SCOPE);
-        end if;
+      if bfm_config.check_packet_length then
+        alert(TB_ERROR, "AXISTREAM VVC = " & to_string(GC_VVC_IDX) & ": Packet length (tlast) is not supported for cosim yet", C_SCOPE);
+      end if;
     end procedure check_bfm_config;
 
   begin

--- a/src/vhdl/uvvm_cosim_uart_vvc_ctrl.vhd
+++ b/src/vhdl/uvvm_cosim_uart_vvc_ctrl.vhd
@@ -91,7 +91,7 @@ begin
 
     function listen_enable (void : t_void) return boolean is
     begin
-      if vhpi_cosim_vvc_listen_enable("UART_VVC", "RX", GC_VVC_IDX) then
+      if vhpi_cosim_vvc_listen_enable("UART_VVC", GC_VVC_IDX) then
         return true;
       else
         return false;

--- a/src/vhdl/vhpi_cosim_methods_pkg.vhd
+++ b/src/vhdl/vhpi_cosim_methods_pkg.vhd
@@ -11,13 +11,12 @@ package vhpi_cosim_methods_pkg is
     constant vvc_type        : in string;
     constant vvc_channel     : in string;
     constant vvc_instance_id : in integer;
-    constant vvc_cfg         : in string
+    constant bfm_cfg         : in string
     );
 
   -- TODO: Replace and add attribute for VHPI implementation
   function vhpi_cosim_vvc_listen_enable (
     constant vvc_type        : string;
-    constant vvc_channel     : string;
     constant vvc_instance_id : integer)
     return boolean;
 
@@ -40,8 +39,9 @@ package vhpi_cosim_methods_pkg is
 
   attribute foreign of vhpi_cosim_start_sim            : procedure is "VHPI uvvm_cosim_lib vhpi_cosim_start_sim";
   attribute foreign of vhpi_cosim_report_vvc_info      : procedure is "VHPI uvvm_cosim_lib vhpi_cosim_report_vvc_info";
-  attribute foreign of vhpi_cosim_transmit_queue_empty : function is "VHPI uvvm_cosim_lib vhpi_cosim_transmit_queue_empty";
-  attribute foreign of vhpi_cosim_transmit_queue_get   : function is "VHPI uvvm_cosim_lib vhpi_cosim_transmit_queue_get";
+  attribute foreign of vhpi_cosim_vvc_listen_enable    : function  is "VHPI uvvm_cosim_lib vhpi_cosim_listen_enable";
+  attribute foreign of vhpi_cosim_transmit_queue_empty : function  is "VHPI uvvm_cosim_lib vhpi_cosim_transmit_queue_empty";
+  attribute foreign of vhpi_cosim_transmit_queue_get   : function  is "VHPI uvvm_cosim_lib vhpi_cosim_transmit_queue_get";
   attribute foreign of vhpi_cosim_receive_queue_put    : procedure is "VHPI uvvm_cosim_lib vhpi_cosim_receive_queue_put";
 
 end package vhpi_cosim_methods_pkg;
@@ -58,7 +58,7 @@ package body vhpi_cosim_methods_pkg is
     constant vvc_type        : in string;
     constant vvc_channel     : in string;
     constant vvc_instance_id : in integer;
-    constant vvc_cfg         : in string
+    constant bfm_cfg         : in string
     ) is
   begin
     report "Error: Should use foreign VHPI implementation" severity failure;
@@ -66,7 +66,6 @@ package body vhpi_cosim_methods_pkg is
 
   function vhpi_cosim_vvc_listen_enable (
     constant vvc_type        : string;
-    constant vvc_channel     : string;
     constant vvc_instance_id : integer)
     return boolean is
   begin

--- a/src/vhdl/vhpi_cosim_methods_pkg.vhd
+++ b/src/vhdl/vhpi_cosim_methods_pkg.vhd
@@ -64,22 +64,13 @@ package body vhpi_cosim_methods_pkg is
     report "Error: Should use foreign VHPI implementation" severity failure;
   end procedure;
 
-  -- TODO: Replace with VHPI implementation
   function vhpi_cosim_vvc_listen_enable (
     constant vvc_type        : string;
     constant vvc_channel     : string;
     constant vvc_instance_id : integer)
     return boolean is
   begin
-    -- Hardcoded to allow listen on UART VVC 1 and AXISTREAM VVC 1
-    -- (setup for receive in the testbench and used in the client example)
-    if (vvc_type = "UART_VVC" and vvc_channel = "RX" and vvc_instance_id = 1) or
-      (vvc_type = "AXISTREAM_VVC" and vvc_instance_id = 1)
-    then
-      return true;
-    else
-      return false;
-    end if;
+    report "Error: Should use foreign VHPI implementation" severity failure;
   end;
 
   function vhpi_cosim_transmit_queue_empty(


### PR DESCRIPTION
- Added JSON-RPC method to selectively enable listening (so we can receive) on a VVC instance
- Replaced hardcoded VHDL function that enabled listening on two specific VVCs (UART instance 1 and AXI-S instance 1) with VHPI implementation.
- Other changes:
  - Renamed `vvc_cfg` field to `bfm_cfg` (since this will primarily reflect BFM config).
