### PR TITLE
Add support for packet-based VVCs (only AXI-Stream for now)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ build/
 *.exe
 *.out
 *.app
+
+# HDL checker
+.hdlchecker/

--- a/examples/axistream_uart/scripts/uart_cosim_test.py
+++ b/examples/axistream_uart/scripts/uart_cosim_test.py
@@ -30,56 +30,6 @@ def main():
 
     time.sleep(1.0)
 
-    print("")
-    print("Transmit with UART VVC")
-    print("----------------------")
-    response = rpc_client.call(method="TransmitBytes", args=None,
-                               kwargs={"vvc_type": "UART_VVC",
-                                       "vvc_id": 0,
-                                       "data": [10, 20, 30, 40]},
-                               one_way=False)
-    print(f"response = {response}")
-
-    time.sleep(10.0)
-
-    print("")
-    print("Receive with AXISTREAM VVC")
-    print("----------------------")
-    response = rpc_client.call(method="ReceiveBytes",
-                               args=None,
-                               kwargs={"vvc_type": "AXISTREAM_VVC",
-                                       "vvc_id": 1,
-                                       "num_bytes": 4,
-                                       "exact_length": False},
-                               one_way=False)
-    print(f"response = {response}")
-
-    print("")
-    print("Transmit with AXISTREAM VVC")
-    print("----------------------")
-    response = rpc_client.call(method="TransmitBytes", args=None,
-                               kwargs={"vvc_type": "AXISTREAM_VVC",
-                                       "vvc_id": 0,
-                                       "data": [9, 8, 7, 4, 1, 3, 0]},
-                               one_way=False)
-    print(f"response = {response}")
-
-    time.sleep(10.0)
-
-    print("")
-    print("Receive with UART VVC")
-    print("----------------------")
-    response = rpc_client.call(method="ReceiveBytes",
-                               args=None,
-                               kwargs={"vvc_type": "UART_VVC",
-                                       "vvc_id": 0,
-                                       "num_bytes": 7,
-                                       "exact_length": False},
-                               one_way=False)
-    print(f"response = {response}")
-
-
-
     NUM_ITERATIONS = 10
     NUM_BYTES = 200
     TIMEOUT_SECONDS = 120

--- a/examples/axistream_uart/src/tb/axistream_uart_uvvm_tb.vhd
+++ b/examples/axistream_uart/src/tb/axistream_uart_uvvm_tb.vhd
@@ -44,8 +44,9 @@ architecture tb of axistream_uart_uvvm_tb is
   --------------------------------------------------------------------------------
   -- Signal declarations
   --------------------------------------------------------------------------------
-  signal clk       : std_logic := '0';
-  signal arst      : std_logic := '0';
+  signal clk             : std_logic := '0';
+  signal arst            : std_logic := '0';
+  signal vvc_config_done : std_logic := '0';
 
 begin
 
@@ -59,7 +60,8 @@ begin
       GC_UART_VVC_IDX          => C_UART_VVC_IDX,
       GC_COSIM_ENABLE          => (GC_TESTCASE = "TC_COSIM"))
     port map (
-      arst => arst
+      arst            => arst,
+      vvc_config_done => vvc_config_done
       );
 
   ------------------------------------------------
@@ -141,6 +143,9 @@ begin
 
       -- No alert for timeout on AXI-S VVC used for receive
       shared_axistream_vvc_config(C_AXIS_VVC_RECEIVE_IDX).bfm_config.max_wait_cycles_severity := NO_ALERT;
+
+      -- Indicate to cosim module that VVC configuration is done
+      vvc_config_done <= '1';
 
       -- Start clock for cosim scheduler
       start_clock(CLOCK_GENERATOR_VVCT, 1, "Start cosim clock generator");

--- a/examples/axistream_uart/src/tb/axistream_uart_uvvm_th.vhd
+++ b/examples/axistream_uart/src/tb/axistream_uart_uvvm_th.vhd
@@ -33,7 +33,8 @@ entity axistream_uart_uvvm_th is
     GC_UART_VVC_IDX          : natural;
     GC_COSIM_ENABLE          : boolean);
   port (
-    arst : in  std_logic
+    arst            : in std_logic;
+    vvc_config_done : in std_logic
   );
 end entity axistream_uart_uvvm_th;
 
@@ -96,7 +97,8 @@ begin
     generic map (
       GC_COSIM_EN => GC_COSIM_ENABLE)
     port map (
-      clk => clk_cosim);
+      clk             => clk_cosim,
+      vvc_config_done => vvc_config_done);
 
   i_axistream_vvc_transmit : entity bitvis_vip_axistream.axistream_vvc
     generic map (

--- a/src/cpp/packet_queue.hpp
+++ b/src/cpp/packet_queue.hpp
@@ -3,6 +3,7 @@
 #include <deque>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace uvvm_cosim {
@@ -23,7 +24,7 @@ public:
     return q.size();
   }
 
-  std::optional<uint8_t> get_byte(void)
+  std::optional<std::pair<uint8_t, bool>> get_byte(void)
   {
     while (!q.empty()) {
 
@@ -38,9 +39,10 @@ public:
       // Pop packet from queue if this was the last byte in packet
       if (q.front().empty()) {
         q.pop_front();
+	return std::make_pair(byte, true);
       }
 
-      return byte;
+      return std::make_pair(byte, false);
     }
 
     return {};

--- a/src/cpp/uvvm_cosim_client.hpp
+++ b/src/cpp/uvvm_cosim_client.hpp
@@ -42,18 +42,20 @@ public:
     return CallMethod<JsonResponse>(requestId++, "TransmitBytes", {vvc_type, vvc_id, data});
   }
 
-  // JsonResponse TransmitPacket(std::string vvc_type, int vvc_id, std::vector<uint8_t> data)
-  // {
-  // }
+  JsonResponse TransmitPacket(std::string vvc_type, int vvc_id, std::vector<uint8_t> pkt)
+  {
+    return CallMethod<JsonResponse>(requestId++, "TransmitPacket", {vvc_type, vvc_id, pkt});
+  }
 
   JsonResponse ReceiveBytes(std::string vvc_type, int vvc_id, int num_bytes, bool exact_length)
   {
     return CallMethod<JsonResponse>(requestId++, "ReceiveBytes", {vvc_type, vvc_id, num_bytes, exact_length});
   }
 
-  // JsonResponse ReceivePacket(std::string vvc_type, int vvc_id);
-  // {
-  // }
+  JsonResponse ReceivePacket(std::string vvc_type, int vvc_id)
+  {
+    return CallMethod<JsonResponse>(requestId++, "ReceivePacket", {vvc_type, vvc_id});
+  }
 
 };
 

--- a/src/cpp/uvvm_cosim_common.cpp
+++ b/src/cpp/uvvm_cosim_common.cpp
@@ -65,6 +65,36 @@ void receive_byte_queue_put(std::string vvc_type, int vvc_instance_id, uint8_t b
   cosim_server->ReceiveQueuePut(vvc_type, vvc_instance_id, byte);
 }
 
+bool transmit_packet_queue_empty(std::string vvc_type, int vvc_instance_id)
+{
+  return cosim_server->TransmitPacketQueueEmpty(vvc_type, vvc_instance_id);
+}
+
+int transmit_packet_queue_get(std::string vvc_type, int vvc_instance_id)
+{
+  auto byte = cosim_server->TransmitPacketQueueGet(vvc_type, vvc_instance_id);
+
+  if (byte) {
+    int data = byte.value().first;
+    if (byte.value().second) {
+      data |= (1 << 8); // 9th bit marks eop
+    }
+    return data;
+  } else {
+    // TODO:
+    // Kill simulation if TransmitPacketQueueGet didn't return anything?
+    sim_printf("Error: TransmitPacketQueueGet did not return a byte");
+    return 0;
+  }
+}
+
+void receive_packet_queue_put(std::string vvc_type, int vvc_instance_id,
+			      uint8_t byte, bool eop)
+{
+  cosim_server->ReceivePacketQueuePut(vvc_type, vvc_instance_id, byte, eop);
+}
+
+
 void start_sim(void)
 {
   cosim_server->WaitForStartSim();

--- a/src/cpp/uvvm_cosim_common.hpp
+++ b/src/cpp/uvvm_cosim_common.hpp
@@ -20,6 +20,13 @@ int transmit_byte_queue_get(std::string vvc_type, int vvc_instance_id);
 void receive_byte_queue_put(std::string vvc_type, int vvc_instance_id,
                             uint8_t byte);
 
+bool transmit_packet_queue_empty(std::string vvc_type, int vvc_instance_id);
+
+int transmit_packet_queue_get(std::string vvc_type, int vvc_instance_id);
+
+void receive_packet_queue_put(std::string vvc_type, int vvc_instance_id,
+			      uint8_t byte, bool eop);
+
 void start_sim(void);
 
 bool terminate_sim(void);

--- a/src/cpp/uvvm_cosim_data.hpp
+++ b/src/cpp/uvvm_cosim_data.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 #include "shared_map.hpp"
 #include "uvvm_cosim_types.hpp"
@@ -54,7 +55,7 @@ private:
 
   size_t packet_queue_size(VvcMapInternal& vvc_map, QueueId qid, VvcInstanceKey vvc);
 
-  auto packet_queue_get_byte(VvcMapInternal& vvc_map, QueueId qid, VvcInstanceKey vvc) -> std::optional<uint8_t>;
+  auto packet_queue_get_byte(VvcMapInternal& vvc_map, QueueId qid, VvcInstanceKey vvc) -> std::optional<std::pair<uint8_t, bool>>;
 
   auto packet_queue_get_pkt(VvcMapInternal& vvc_map, QueueId qid, VvcInstanceKey vvc) -> std::vector<uint8_t>;
 
@@ -123,7 +124,7 @@ public:
 
   size_t packet_queue_size(QueueId qid, VvcInstanceKey vvc);
 
-  auto packet_queue_get_byte(QueueId qid, VvcInstanceKey vvc) -> std::optional<uint8_t>;
+  auto packet_queue_get_byte(QueueId qid, VvcInstanceKey vvc) -> std::optional<std::pair<uint8_t, bool>>;
 
   auto packet_queue_get_pkt(QueueId qid, VvcInstanceKey vvc) -> std::vector<uint8_t>;
 

--- a/src/cpp/uvvm_cosim_foreign_fli.cpp
+++ b/src/cpp/uvvm_cosim_foreign_fli.cpp
@@ -76,6 +76,29 @@ void uvvm_cosim_foreign_receive_byte_queue_put(mtiVariableIdT vvc_type,
   uvvm_cosim::receive_byte_queue_put(vvc_type_str, vvc_instance_id, byte);
 }
 
+int uvvm_cosim_foreign_transmit_packet_queue_empty(mtiVariableIdT vvc_type,
+                                                 int vvc_instance_id) {
+  std::string vvc_type_str = get_string(vvc_type);
+
+  return uvvm_cosim::transmit_packet_queue_empty(vvc_type_str, vvc_instance_id) ? 1 : 0;
+}
+
+int uvvm_cosim_foreign_transmit_packet_queue_get(mtiVariableIdT vvc_type,
+						 int vvc_instance_id) {
+  std::string vvc_type_str = get_string(vvc_type);
+
+  return uvvm_cosim::transmit_packet_queue_get(vvc_type_str, vvc_instance_id);
+}
+
+void uvvm_cosim_foreign_receive_packet_queue_put(mtiVariableIdT vvc_type,
+						 int vvc_instance_id,
+						 int byte, int end_of_packet)
+{
+  std::string vvc_type_str = get_string(vvc_type);
+  bool eop = end_of_packet == 1 ? true : false;
+  uvvm_cosim::receive_packet_queue_put(vvc_type_str, vvc_instance_id, byte, eop);
+}
+
 static void start_of_sim_cb(void* p)
 {
   uvvm_cosim::start_of_sim();

--- a/src/cpp/uvvm_cosim_foreign_vhpi.cpp
+++ b/src/cpp/uvvm_cosim_foreign_vhpi.cpp
@@ -57,7 +57,7 @@ static void uvvm_cosim_foreign_transmit_byte_queue_empty(const vhpiCbDataT* p_cb
   return_vhpi_int(p_cb_data, empty ? 1 : 0);
 }
 
-void uvvm_cosim_foreign_transmit_byte_queue_get(const vhpiCbDataT* p_cb_data)
+static void uvvm_cosim_foreign_transmit_byte_queue_get(const vhpiCbDataT* p_cb_data)
 {
   std::string vvc_type = get_vhpi_str_param_by_index(p_cb_data, 0);
   int vvc_instance_id  = get_vhpi_int_param_by_index(p_cb_data, 1);
@@ -67,7 +67,7 @@ void uvvm_cosim_foreign_transmit_byte_queue_get(const vhpiCbDataT* p_cb_data)
   return_vhpi_int(p_cb_data, data);
 }
 
-void uvvm_cosim_foreign_receive_byte_queue_put(const vhpiCbDataT* p_cb_data)
+static void uvvm_cosim_foreign_receive_byte_queue_put(const vhpiCbDataT* p_cb_data)
 {
   std::string vvc_type = get_vhpi_str_param_by_index(p_cb_data, 0);
   int vvc_instance_id  = get_vhpi_int_param_by_index(p_cb_data, 1);
@@ -76,7 +76,38 @@ void uvvm_cosim_foreign_receive_byte_queue_put(const vhpiCbDataT* p_cb_data)
   uvvm_cosim::receive_byte_queue_put(vvc_type, vvc_instance_id, byte);
 }
 
-void uvvm_cosim_foreign_vvc_listen_enable(const vhpiCbDataT* p_cb_data)
+static void uvvm_cosim_foreign_transmit_packet_queue_empty(const vhpiCbDataT* p_cb_data)
+{
+  std::string vvc_type = get_vhpi_str_param_by_index(p_cb_data, 0);
+  int vvc_instance_id  = get_vhpi_int_param_by_index(p_cb_data, 1);
+
+  bool empty = uvvm_cosim::transmit_packet_queue_empty(vvc_type, vvc_instance_id);
+
+  return_vhpi_int(p_cb_data, empty ? 1 : 0);
+}
+
+static void uvvm_cosim_foreign_transmit_packet_queue_get(const vhpiCbDataT* p_cb_data)
+{
+  std::string vvc_type = get_vhpi_str_param_by_index(p_cb_data, 0);
+  int vvc_instance_id  = get_vhpi_int_param_by_index(p_cb_data, 1);
+
+  int byte_and_eop = uvvm_cosim::transmit_packet_queue_get(vvc_type, vvc_instance_id);
+
+  return_vhpi_int(p_cb_data, byte_and_eop);
+}
+
+static void uvvm_cosim_foreign_receive_packet_queue_put(const vhpiCbDataT* p_cb_data)
+{
+  std::string vvc_type = get_vhpi_str_param_by_index(p_cb_data, 0);
+  int vvc_instance_id  = get_vhpi_int_param_by_index(p_cb_data, 1);
+  uint8_t byte         = get_vhpi_int_param_by_index(p_cb_data, 2);
+  int end_of_packet    = get_vhpi_int_param_by_index(p_cb_data, 3);
+  bool eop             = end_of_packet == 1 ? true : false;
+
+  uvvm_cosim::receive_packet_queue_put(vvc_type, vvc_instance_id, byte, eop);
+}
+
+static void uvvm_cosim_foreign_vvc_listen_enable(const vhpiCbDataT* p_cb_data)
 {
   std::string vvc_type = get_vhpi_str_param_by_index(p_cb_data, 0);
   int vvc_instance_id  = get_vhpi_int_param_by_index(p_cb_data, 1);
@@ -86,7 +117,7 @@ void uvvm_cosim_foreign_vvc_listen_enable(const vhpiCbDataT* p_cb_data)
   return_vhpi_int(p_cb_data, listen ? 1 : 0);
 }
 
-void uvvm_cosim_foreign_report_vvc_info(const vhpiCbDataT* p_cb_data)
+static void uvvm_cosim_foreign_report_vvc_info(const vhpiCbDataT* p_cb_data)
 {
   std::string vvc_type    = get_vhpi_str_param_by_index(p_cb_data, 0);
   std::string vvc_channel = get_vhpi_str_param_by_index(p_cb_data, 1);
@@ -134,6 +165,21 @@ static void register_foreign_methods(void)
 
   register_vhpi_foreign_method(uvvm_cosim_foreign_receive_byte_queue_put,
 			       "uvvm_cosim_foreign_receive_byte_queue_put",
+			       c_lib_name,
+			       vhpiProcF);
+
+  register_vhpi_foreign_method(uvvm_cosim_foreign_transmit_packet_queue_empty,
+			       "uvvm_cosim_foreign_transmit_packet_queue_empty",
+			       c_lib_name,
+			       vhpiFuncF);
+
+  register_vhpi_foreign_method(uvvm_cosim_foreign_transmit_packet_queue_get,
+			       "uvvm_cosim_foreign_transmit_packet_queue_get",
+			       c_lib_name,
+			       vhpiFuncF);
+
+  register_vhpi_foreign_method(uvvm_cosim_foreign_receive_packet_queue_put,
+			       "uvvm_cosim_foreign_receive_packet_queue_put",
 			       c_lib_name,
 			       vhpiProcF);
 

--- a/src/cpp/uvvm_cosim_server.hpp
+++ b/src/cpp/uvvm_cosim_server.hpp
@@ -83,7 +83,7 @@ public:
   }
 
   // --------------------------------------------------------------------------
-  // Methods used by VHPI code
+  // Methods used by VHPI/FLI code
   // --------------------------------------------------------------------------
 
   void StartListening()
@@ -110,6 +110,12 @@ public:
   std::optional<uint8_t> TransmitQueueGet(std::string vvc_type, int vvc_instance_id);
 
   void ReceiveQueuePut(std::string vvc_type, int vvc_instance_id, uint8_t byte);
+
+  bool TransmitPacketQueueEmpty(std::string vvc_type, int vvc_instance_id);
+
+  auto TransmitPacketQueueGet(std::string vvc_type, int vvc_instance_id) -> std::optional<std::pair<uint8_t, bool>>;
+
+  void ReceivePacketQueuePut(std::string vvc_type, int vvc_instance_id, uint8_t byte, bool eop);
 
 };
   

--- a/src/cpp/uvvm_cosim_types.hpp
+++ b/src/cpp/uvvm_cosim_types.hpp
@@ -28,10 +28,13 @@ inline std::string to_string(const VvcInstanceKey& vvc)
 }
 
 struct VvcConfig {
-  std::map<std::string, int> bfm_cfg;
+  // Common config options used with most/all VVC types
   bool listen_enable = false;
-  bool cosim_support;
-  bool packet_based;
+  bool cosim_support = false;
+  bool packet_based = false;
+
+  // Map for VVC/BFM-specific config options
+  std::map<std::string, int> bfm_cfg;
 };
 
 // Used as value in std::map of all VVCs in server

--- a/src/python/example_client_requests-lib.py
+++ b/src/python/example_client_requests-lib.py
@@ -1,3 +1,6 @@
+# Short example of how the requests library can be
+# used to send requests to the cosim server.
+
 import itertools
 import requests
 import time
@@ -29,7 +32,7 @@ def main():
     print(f"VVC list response: {response}")
 
     print("")
-    print("Enable listening on UART_VVC 1 and AXISTREAM_VVC 1")
+    print("Enable listening on UART_VVC 1 and AXISTREAM_VVC 1+3")
     payload = {
         "method": "SetVvcListenEnable",
         "params": {"vvc_type": "UART_VVC",
@@ -44,7 +47,7 @@ def main():
 
     payload = {
         "method": "SetVvcListenEnable",
-        "params": {"vvc_type": "UART_VVC",
+        "params": {"vvc_type": "AXISTREAM_VVC",
                    "vvc_id": 1,
                    "enable": True},
         "jsonrpc": "2.0",
@@ -52,7 +55,21 @@ def main():
     }
     requests.post(url, json=payload).json()
 
+    payload = {
+        "method": "SetVvcListenEnable",
+        "params": {"vvc_type": "AXISTREAM_VVC",
+                   "vvc_id": 3,
+                   "enable": True},
+        "jsonrpc": "2.0",
+        "id": next(id),
+    }
+    requests.post(url, json=payload).json()
+
     time.sleep(0.5)
+
+    ###########################################################################
+    # Transmit and receive some bytes on UART VVCs 0 and 1
+    ###########################################################################
 
     payload = {
         "method": "TransmitBytes",
@@ -74,6 +91,66 @@ def main():
                    "vvc_id": 1,
                    "num_bytes": 5,
                    "exact_length": False},
+        "jsonrpc": "2.0",
+        "id": next(id),
+    }
+    response = requests.post(url, json=payload).json()
+    print(f"request = {payload}")
+    print(f"response = {response}")
+
+    ###########################################################################
+    # Transmit and receive some bytes on AXISTREAM VVCs 0 and 1
+    ###########################################################################
+
+    payload = {
+        "method": "TransmitBytes",
+        "params": {"vvc_type": "AXISTREAM_VVC",
+                   "vvc_id": 0,
+                   "data": [10, 20, 30, 40, 50]},
+        "jsonrpc": "2.0",
+        "id": next(id),
+    }
+    response = requests.post(url, json=payload).json()
+    print(f"request = {payload}")
+    print(f"response = {response}")
+
+    time.sleep(1.0)
+
+    payload = {
+        "method": "ReceiveBytes",
+        "params": {"vvc_type": "AXISTREAM_VVC",
+                   "vvc_id": 1,
+                   "num_bytes": 5,
+                   "exact_length": False},
+        "jsonrpc": "2.0",
+        "id": next(id),
+    }
+    response = requests.post(url, json=payload).json()
+    print(f"request = {payload}")
+    print(f"response = {response}")
+
+    ###########################################################################
+    # Transmit and receive a packet on AXISTREAM VVCs 2 and 3
+    ###########################################################################
+
+    payload = {
+        "method": "TransmitPacket",
+        "params": {"vvc_type": "AXISTREAM_VVC",
+                   "vvc_id": 2,
+                   "data": [11, 21, 31, 41, 51]},
+        "jsonrpc": "2.0",
+        "id": next(id),
+    }
+    response = requests.post(url, json=payload).json()
+    print(f"request = {payload}")
+    print(f"response = {response}")
+
+    time.sleep(1.0)
+
+    payload = {
+        "method": "ReceivePacket",
+        "params": {"vvc_type": "AXISTREAM_VVC",
+                   "vvc_id": 3},
         "jsonrpc": "2.0",
         "id": next(id),
     }

--- a/src/python/example_client_tinyrpc-lib.py
+++ b/src/python/example_client_tinyrpc-lib.py
@@ -1,8 +1,10 @@
+# Short example of how the tinyrpc library can be
+# used to send requests to the cosim server.
+
 from tinyrpc.protocols.jsonrpc import JSONRPCProtocol
 from tinyrpc.transports.http import HttpPostClientTransport
 from tinyrpc import RPCClient
 import time
-
 
 def main():
     rpc_client = RPCClient(

--- a/src/vhdl/uvvm_cosim.vhd
+++ b/src/vhdl/uvvm_cosim.vhd
@@ -25,7 +25,8 @@ entity uvvm_cosim is
   generic (
     GC_COSIM_EN : boolean := false);
   port (
-    clk : in std_logic);
+    clk             : in std_logic;
+    vvc_config_done : in std_logic);
 end entity uvvm_cosim;
 
 
@@ -46,16 +47,16 @@ begin
     variable bfm_cfg         : line :=  null;
   begin
 
-    await_uvvm_initialization(VOID);
-
-    log(ID_SEQUENCER, "UVVM initialization complete!", C_SCOPE);
-
     if GC_COSIM_EN then
       log(ID_SEQUENCER, "Co-simulation enabled", C_SCOPE);
     else
       log(ID_SEQUENCER, "Co-simulation disabled", C_SCOPE);
       wait; -- Wait forever
     end if;
+
+    wait until vvc_config_done = '1';
+
+    log(ID_SEQUENCER, "Reporting VVC configs", C_SCOPE);
 
     -- Check which VVCs were registered in this testbench
     for idx in 0 to shared_vvc_activity_register.priv_get_num_registered_vvcs(VOID)-1 loop

--- a/src/vhdl/uvvm_cosim_axis_vvc_ctrl.vhd
+++ b/src/vhdl/uvvm_cosim_axis_vvc_ctrl.vhd
@@ -44,26 +44,17 @@ begin
 
   p_transmit : process
     alias vvc_status         : t_vvc_status is shared_axistream_vvc_status(GC_VVC_IDX);
+    alias bfm_config         : t_axistream_bfm_config is shared_axistream_vvc_config(GC_VVC_IDX).bfm_config;
     constant C_CMD_QUEUE_MAX : natural := 32;
     variable v_data          : t_slv_array(0 to C_AXISTREAM_VVC_CMD_DATA_MAX_BYTES-1)(7 downto 0);
-    variable v_byte_idx      : integer range 0 to C_AXISTREAM_VVC_CMD_DATA_MAX_BYTES;
-  begin
+    variable v_data_size     : integer range 0 to C_AXISTREAM_VVC_CMD_DATA_MAX_BYTES;
 
-    wait until init_done = '1';
-    wait until rising_edge(clk);
-
-    -- Do nothing if no VVC was registered for this index
-    if vvc_idx_in_use = '0' then
-      wait;
-    end if;
-
-    log(ID_SEQUENCER, "Cosim for AXISTREAM VVC " & to_string(GC_VVC_IDX) & " ENABLED.", C_SCOPE);
-
-    loop
-      wait until rising_edge(clk);
-
-      v_byte_idx := 0;
-
+    procedure fetch_bytes_to_transmit (
+      variable data_out      : out t_slv_array;
+      variable data_size_out : out integer)
+    is
+      variable v_byte_idx : integer := 0;
+    begin
       -- Fetch bytes from cosim transmit queue
       while uvvm_cosim_foreign_transmit_byte_queue_empty(C_VVC_TYPE, GC_VVC_IDX) = 0 loop
 
@@ -83,21 +74,54 @@ begin
         -- For packet based transmit use transmit_pkt_queue_get function (not
         -- implemented yet) and collect data in an slv_array buffer
         -- until the 9th bit in v_data (end of packet) is set.
-        v_data(v_byte_idx) := std_logic_vector(to_unsigned(uvvm_cosim_foreign_transmit_byte_queue_get(C_VVC_TYPE, GC_VVC_IDX), v_data(0)'length));
+        data_out(v_byte_idx) := std_logic_vector(to_unsigned(uvvm_cosim_foreign_transmit_byte_queue_get(C_VVC_TYPE, GC_VVC_IDX), data_out(0)'length));
 
         v_byte_idx := v_byte_idx + 1;
 
         if uvvm_cosim_foreign_transmit_byte_queue_empty(C_VVC_TYPE, GC_VVC_IDX) = 1 then
           log(ID_SEQUENCER, "Transmit queue now empty for VVC index " & to_string(GC_VVC_IDX), C_SCOPE);
         end if;
-
       end loop;
 
+      data_size_out := v_byte_idx;
+
+    end procedure fetch_bytes_to_transmit;
+
+    procedure fetch_packet_to_transmit (
+      variable data_out      : out t_slv_array;
+      variable data_size_out : out integer)
+    is
+      variable v_byte_idx : integer := 0;
+    begin
+    end procedure fetch_packet_to_transmit;
+
+  begin
+
+    wait until init_done = '1';
+    wait until rising_edge(clk);
+
+    -- Do nothing if no VVC was registered for this index
+    if vvc_idx_in_use = '0' then
+      wait;
+    end if;
+
+    log(ID_SEQUENCER, "Cosim for AXISTREAM VVC " & to_string(GC_VVC_IDX) & " ENABLED.", C_SCOPE);
+
+    loop
+      wait until rising_edge(clk);
+
+      -- Fetch packet or bytes from cosim transmit queue
+      if bfm_config.check_packet_length then
+        fetch_packet_to_transmit (v_data, v_data_size);
+      else
+        fetch_bytes_to_transmit (v_data, v_data_size);
+      end if;
+
       -- Transmit any bytes we got from cosim buffer
-      if v_byte_idx > 0 then
-        log(ID_SEQUENCER, "Got " & to_string(v_byte_idx) & " bytes to transmit on VVC " & to_string(GC_VVC_IDX), C_SCOPE);
-        axistream_transmit(AXISTREAM_VVCT, GC_VVC_IDX, v_data(0 to v_byte_idx-1),
-                           "Transmit " & to_string(v_byte_idx) & " bytes from uvvm_cosim_axis_vvc_ctrl");
+      if v_data_size > 0 then
+        log(ID_SEQUENCER, "Got " & to_string(v_data_size) & " bytes to transmit on VVC " & to_string(GC_VVC_IDX), C_SCOPE);
+        axistream_transmit(AXISTREAM_VVCT, GC_VVC_IDX, v_data(0 to v_data_size-1),
+                           "Transmit " & to_string(v_data_size) & " bytes from uvvm_cosim_axis_vvc_ctrl");
       end if;
 
     end loop;

--- a/src/vhdl/uvvm_cosim_foreign_pkg_body.vhd
+++ b/src/vhdl/uvvm_cosim_foreign_pkg_body.vhd
@@ -59,4 +59,30 @@ package body uvvm_cosim_foreign_pkg is
     report "Error: Should use foreign implementation" severity failure;
   end procedure;
 
+  impure function uvvm_cosim_foreign_transmit_packet_queue_empty(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer) return integer is
+  begin
+    report "Error: Should use foreign implementation" severity failure;
+    return 0;
+  end function;
+
+  impure function uvvm_cosim_foreign_transmit_packet_queue_get(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer) return integer is
+  begin
+    report "Error: Should use foreign implementation" severity failure;
+    return 0;
+  end function;
+
+  procedure uvvm_cosim_foreign_receive_packet_queue_put(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer;
+    constant byte            : in integer;
+    constant end_of_packet   : in integer
+    ) is
+  begin
+    report "Error: Should use foreign implementation" severity failure;
+  end procedure;
+
 end package body uvvm_cosim_foreign_pkg;

--- a/src/vhdl/uvvm_cosim_foreign_pkg_fli.vhd
+++ b/src/vhdl/uvvm_cosim_foreign_pkg_fli.vhd
@@ -42,12 +42,29 @@ package uvvm_cosim_foreign_pkg is
     constant vvc_instance_id : in integer;
     constant byte            : in integer);
 
-  attribute foreign of uvvm_cosim_foreign_start_sim                 : procedure is "uvvm_cosim_foreign_start_sim libuvvm_cosim_fli.so";
-  attribute foreign of uvvm_cosim_foreign_terminate_sim             : function is "uvvm_cosim_foreign_terminate_sim libuvvm_cosim_fli.so";
-  attribute foreign of uvvm_cosim_foreign_report_vvc_info           : procedure is "uvvm_cosim_foreign_report_vvc_info libuvvm_cosim_fli.so";
-  attribute foreign of uvvm_cosim_foreign_vvc_listen_enable         : function is "uvvm_cosim_foreign_vvc_listen_enable libuvvm_cosim_fli.so";
-  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_empty : function is "uvvm_cosim_foreign_transmit_byte_queue_empty libuvvm_cosim_fli.so";
-  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_get   : function is "uvvm_cosim_foreign_transmit_byte_queue_get libuvvm_cosim_fli.so";
-  attribute foreign of uvvm_cosim_foreign_receive_byte_queue_put    : procedure is "uvvm_cosim_foreign_receive_byte_queue_put libuvvm_cosim_fli.so";
+  impure function uvvm_cosim_foreign_transmit_packet_queue_empty(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer) return integer;
+
+  impure function uvvm_cosim_foreign_transmit_packet_queue_get(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer) return integer;
+
+  procedure uvvm_cosim_foreign_receive_packet_queue_put(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer;
+    constant byte            : in integer;
+    constant end_of_packet   : in integer);
+
+  attribute foreign of uvvm_cosim_foreign_start_sim                   : procedure is "uvvm_cosim_foreign_start_sim libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_terminate_sim               : function is "uvvm_cosim_foreign_terminate_sim libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_report_vvc_info             : procedure is "uvvm_cosim_foreign_report_vvc_info libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_vvc_listen_enable           : function is "uvvm_cosim_foreign_vvc_listen_enable libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_empty   : function is "uvvm_cosim_foreign_transmit_byte_queue_empty libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_get     : function is "uvvm_cosim_foreign_transmit_byte_queue_get libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_receive_byte_queue_put      : procedure is "uvvm_cosim_foreign_receive_byte_queue_put libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_transmit_packet_queue_empty : function is "uvvm_cosim_foreign_transmit_packet_queue_empty libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_transmit_packet_queue_get   : function is "uvvm_cosim_foreign_transmit_packet_queue_get libuvvm_cosim_fli.so";
+  attribute foreign of uvvm_cosim_foreign_receive_packet_queue_put    : procedure is "uvvm_cosim_foreign_receive_packet_queue_put libuvvm_cosim_fli.so";
 
 end package uvvm_cosim_foreign_pkg;

--- a/src/vhdl/uvvm_cosim_foreign_pkg_vhpi.vhd
+++ b/src/vhdl/uvvm_cosim_foreign_pkg_vhpi.vhd
@@ -42,12 +42,29 @@ package uvvm_cosim_foreign_pkg is
     constant vvc_instance_id : in integer;
     constant byte            : in integer);
 
-  attribute foreign of uvvm_cosim_foreign_start_sim                 : procedure is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_start_sim";
-  attribute foreign of uvvm_cosim_foreign_terminate_sim             : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_terminate_sim";
-  attribute foreign of uvvm_cosim_foreign_report_vvc_info           : procedure is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_report_vvc_info";
-  attribute foreign of uvvm_cosim_foreign_vvc_listen_enable         : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_vvc_listen_enable";
-  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_empty : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_transmit_byte_queue_empty";
-  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_get   : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_transmit_byte_queue_get";
-  attribute foreign of uvvm_cosim_foreign_receive_byte_queue_put    : procedure is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_receive_byte_queue_put";
+  impure function uvvm_cosim_foreign_transmit_packet_queue_empty(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer) return integer;
+
+  impure function uvvm_cosim_foreign_transmit_packet_queue_get(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer) return integer;
+
+  procedure uvvm_cosim_foreign_receive_packet_queue_put(
+    constant vvc_type        : in string;
+    constant vvc_instance_id : in integer;
+    constant byte            : in integer;
+    constant end_of_packet   : in integer);
+
+  attribute foreign of uvvm_cosim_foreign_start_sim                   : procedure is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_start_sim";
+  attribute foreign of uvvm_cosim_foreign_terminate_sim               : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_terminate_sim";
+  attribute foreign of uvvm_cosim_foreign_report_vvc_info             : procedure is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_report_vvc_info";
+  attribute foreign of uvvm_cosim_foreign_vvc_listen_enable           : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_vvc_listen_enable";
+  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_empty   : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_transmit_byte_queue_empty";
+  attribute foreign of uvvm_cosim_foreign_transmit_byte_queue_get     : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_transmit_byte_queue_get";
+  attribute foreign of uvvm_cosim_foreign_receive_byte_queue_put      : procedure is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_receive_byte_queue_put";
+  attribute foreign of uvvm_cosim_foreign_transmit_packet_queue_empty : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_transmit_packet_queue_empty";
+  attribute foreign of uvvm_cosim_foreign_transmit_packet_queue_get   : function is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_transmit_packet_queue_get";
+  attribute foreign of uvvm_cosim_foreign_receive_packet_queue_put    : procedure is "VHPI libuvvm_cosim_vhpi.so uvvm_cosim_foreign_receive_packet_queue_put";
 
 end package uvvm_cosim_foreign_pkg;

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -13,6 +13,13 @@ target_include_directories(test_byte_queue PUBLIC
   "${PROJECT_SOURCE_DIR}/thirdparty/json-rpc-cxx/vendor"
 )
 
+add_executable(test_packet_queue test_packet_queue.cpp)
+target_link_libraries(test_packet_queue PRIVATE Catch2::Catch2WithMain)
+target_include_directories(test_packet_queue PUBLIC
+  "${PROJECT_SOURCE_DIR}/src/cpp"
+  "${PROJECT_SOURCE_DIR}/thirdparty/json-rpc-cxx/vendor"
+)
+
 add_executable(test_uvvm_cosim_data test_uvvm_cosim_data.cpp ${PROJECT_SOURCE_DIR}/src/cpp/uvvm_cosim_data.cpp)
 target_link_libraries(test_uvvm_cosim_data PRIVATE Catch2::Catch2WithMain)
 target_include_directories(test_uvvm_cosim_data PUBLIC
@@ -30,6 +37,7 @@ target_include_directories(test_uvvm_cosim_types PUBLIC
 include(Catch)
 set(CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
 catch_discover_tests(test_byte_queue)
+catch_discover_tests(test_packet_queue)
 catch_discover_tests(test_uvvm_cosim_data)
 catch_discover_tests(test_uvvm_cosim_types)
 
@@ -42,6 +50,7 @@ if (ENABLE_COVERAGE)
 				 EXCLUDE "/usr/include/*" "${PROJECT_SOURCE_DIR}/thirdparty/*" "${CMAKE_BINARY_DIR}/_deps/*")
 
   append_coverage_compiler_flags_to_target(test_byte_queue)
+  append_coverage_compiler_flags_to_target(test_packet_queue)
   append_coverage_compiler_flags_to_target(test_uvvm_cosim_data)
   append_coverage_compiler_flags_to_target(test_uvvm_cosim_types)
 

--- a/test/cpp/test_packet_queue.cpp
+++ b/test/cpp/test_packet_queue.cpp
@@ -1,0 +1,282 @@
+#include <catch2/catch_test_macros.hpp>
+#include <array>
+#include <cstdlib>
+#include <vector>
+#include "packet_queue.hpp"
+
+using namespace uvvm_cosim;
+
+TEST_CASE("PacketQueue_empty_and_size")
+{
+  INFO("PacketQueue_empty_and_size test start.");
+
+  PacketQueue q;
+
+  INFO("Check empty/size initially");
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+
+  INFO("Check empty/size after put_pkt and after get_pkt");
+  q.put_pkt({0, 1, 2, 3, 4});
+  REQUIRE_FALSE(q.empty());
+  REQUIRE(q.size() == 1);
+  (void) q.get_pkt();
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+
+  INFO("Put individual bytes in pkt buffer without completing packet");
+  q.put_byte(0x01, false);
+  q.put_byte(0x02, false);
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+
+  INFO("Complete packet and expect queue to be not empty");
+  q.put_byte(0x03, true);
+  REQUIRE_FALSE(q.empty());
+  REQUIRE(q.size() == 1);
+
+  INFO("Get some bytes from packet. Queue should remain non-empty until whole packet is read out");
+  (void) q.get_byte();
+  (void) q.get_byte();
+  REQUIRE_FALSE(q.empty());
+  REQUIRE(q.size() == 1);
+
+  INFO("Get last byte in packet. Queue should go empty.");
+  (void) q.get_byte();
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+
+  INFO("Put a packet using put_byte() method, get with get_pkt(), queue should go empty again.");
+  q.put_byte(0x01, false);
+  q.put_byte(0x02, true);
+  REQUIRE_FALSE(q.empty());
+  (void) q.get_pkt();
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+}
+
+TEST_CASE("PacketQueue_put_and_get_pkt")
+{
+  INFO("PacketQueue_put_and_get_pkt test start.");
+
+  PacketQueue q;
+
+  constexpr int NUM_PACKETS = 10;
+  constexpr int PKT_SIZE_MAX = 100;
+
+  std::array<std::vector<uint8_t>, NUM_PACKETS> packets;
+
+  srand(1234); // using constant seed
+
+  INFO("Put random packets in queue.");
+  for (int i = 0; i < NUM_PACKETS; i++) {
+    int pkt_size = (rand() % PKT_SIZE_MAX) + 1;
+
+    for (int j = 0; j < pkt_size; j++) {
+      packets[i].push_back(rand() % 256);
+    }
+
+    q.put_pkt(packets[i]);
+    REQUIRE_FALSE(q.empty());
+    REQUIRE(q.size() == i+1);
+  }
+
+  INFO("Read out packets and check packet contents.");
+  for (int i = 0; i < NUM_PACKETS; i++) {
+    REQUIRE_FALSE(q.empty());
+    REQUIRE(q.size() == NUM_PACKETS-i);
+    
+    std::vector<uint8_t> pkt = q.get_pkt();
+
+    REQUIRE(pkt == packets[i]);
+  }
+
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+}
+
+TEST_CASE("PacketQueue_put_and_get_byte")
+{
+  INFO("PacketQueue_put_and_get_byte test start.");
+
+  PacketQueue q;
+
+  constexpr int NUM_PACKETS = 10;
+  constexpr int PKT_SIZE_MAX = 100;
+
+  std::array<std::vector<uint8_t>, NUM_PACKETS> packets;
+
+  srand(1234); // using constant seed
+
+  INFO("Put random packets in queue one byte at a time.");
+  for (int i = 0; i < NUM_PACKETS; i++) {
+    int pkt_size = (rand() % PKT_SIZE_MAX) + 1;
+
+    for (int j = 0; j < pkt_size; j++) {
+      packets[i].push_back(rand() % 256);
+
+      if (j+1 == pkt_size) {
+	q.put_byte(packets[i].back(), true); // Last byte in pkt
+      } else {
+	q.put_byte(packets[i].back(), false);
+      }
+    }
+
+    REQUIRE_FALSE(q.empty());
+    REQUIRE(q.size() == i+1);
+  }
+
+  INFO("Read out packets from queue one byte at a time and check packet contents.");
+  for (int i = 0; i < NUM_PACKETS; i++) {
+    REQUIRE_FALSE(q.empty());
+    REQUIRE(q.size() == NUM_PACKETS-i);
+
+    std::vector<uint8_t> pkt;
+    bool pkt_done = false;
+
+    do {
+      std::optional<std::pair<uint8_t, bool>> byte = q.get_byte();
+      REQUIRE(byte.has_value());
+      pkt.push_back(byte.value().first);
+      pkt_done = byte.value().second;
+    } while (!pkt_done);
+
+    REQUIRE(pkt == packets[i]);
+  }
+
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+
+  INFO("Check that get_byte() on empty queue returns empty optional.");
+  std::optional<std::pair<uint8_t, bool>> byte;
+  byte = q.get_byte();
+
+  REQUIRE_FALSE(byte.has_value());
+}
+
+TEST_CASE("PacketQueue_mixed")
+{
+  INFO("PacketQueue_mixed test start.");
+
+  PacketQueue q;
+
+  // Different "modes" to test.
+  // FULL_PKT and BYTES_ONLY is used with put_byte()/put_pkt(),
+  // while MIXED mode is also used with get_byte()/get_pkt() in the test below.
+  enum pkt_queue_mode_t {
+    FULL_PKT,   // Use put_pkt() or get_pkt() for full packet
+    BYTES_ONLY, // Use put_byte() or get_byte() to put/get full packet
+    MIXED       // Use get_byte() followed by get_pkt().
+  };
+
+  // NOTE:
+  // Mixed mode is only used with get_byte()/get_pkt().  Since
+  // it's possible to get a few bytes of a packet and then retrieve
+  // the remaining packet with get_pkt.  But it's not possible to put
+  // a few bytes of a packet with put_byte() and then complete it with
+  // put_pkt(). In that case put_byte() would just start a packet in
+  // an internal buffer in PacketQueue, will put_pkt() will put an
+  // independent packet first instead of completing the packet started
+  // by put_byte().
+
+  // The rationale for how this is implemented is that only complete
+  // packets that have been put in the queue should count towards
+  // size() and empty().
+  // The way it's used in the cosim code is that the JSON-RPC side will only put and get full packets, while the VHDL side will only put and get individual bytes.
+  // We don't want the JSON-RPC side to fetch incomplete packets.
+  // But we allow the VHDL side to nibble away at a packet one byte at a time without affecting size()/empty status until it has read the last byte of a packet.
+
+  constexpr int NUM_PACKETS = 20;
+  constexpr int PKT_SIZE_MIN = 10;
+  constexpr int PKT_SIZE_MAX = 100;
+
+  std::array<std::vector<uint8_t>, NUM_PACKETS> packets;
+
+  pkt_queue_mode_t mode = FULL_PKT;
+
+  srand(1234); // using constant seed
+
+  INFO("Put random packets in queue in different ways (full pkt, byte at a time, mixed).");
+  for (int i = 0; i < NUM_PACKETS; i++) {
+    int pkt_size = (rand() % (PKT_SIZE_MAX + 1 - PKT_SIZE_MIN)) + PKT_SIZE_MIN;
+
+    // Used only with mode == MIXED
+    std::vector<uint8_t> pkt_second_half;
+
+    for (int j = 0; j < pkt_size; j++) {
+      packets[i].push_back(rand() % 256);
+
+      if (mode == BYTES_ONLY) {
+	if (j+1 == pkt_size) {
+	  q.put_byte(packets[i].back(), true); // Last byte in pkt
+	} else {
+	  q.put_byte(packets[i].back(), false);
+	}
+      } else if (mode == MIXED) {
+	// Read individual bytes of first half of packet,
+	// read out the second half of packet in one go as vector
+	if (i < pkt_size/2) {
+	  q.put_byte(packets[i].back(), false);
+	} else {
+	  pkt_second_half.push_back(packets[i].back());
+	}
+      }
+    }
+
+    if (mode == FULL_PKT) {
+      q.put_pkt(packets[i]);
+    } else if (mode == MIXED) {
+      q.put_pkt(pkt_second_half);
+    }
+
+    REQUIRE_FALSE(q.empty());
+    REQUIRE(q.size() == i+1);
+
+    // Iterate through FULL_PKT and BYTES_ONLY mode.
+    mode = (mode == FULL_PKT ? BYTES_ONLY : FULL_PKT);
+  }
+
+  INFO("Read out packets from queue in different ways (full pkt, byte at a time, mixed).");
+
+  mode = MIXED; // Start with different mode
+  
+  for (int i = 0; i < NUM_PACKETS; i++) {
+    REQUIRE_FALSE(q.empty());
+    REQUIRE(q.size() == NUM_PACKETS-i);
+
+    std::vector<uint8_t> pkt; // Used for mode == BYTES_ONLY or mode == MIXED
+
+    if (mode == FULL_PKT) {
+      pkt = q.get_pkt();
+
+    } else if (mode == BYTES_ONLY) {
+      bool pkt_done = false;
+      do {
+	std::optional<std::pair<uint8_t, bool>> byte = q.get_byte();
+	REQUIRE(byte.has_value());
+	pkt.push_back(byte.value().first);
+	pkt_done = byte.value().second;
+      } while (!pkt_done);
+
+    } else if (mode == MIXED) {
+      for (int i = 0; i < packets[i].size() / 2; i++) {
+	std::optional<std::pair<uint8_t, bool>> byte = q.get_byte();
+	REQUIRE(byte.has_value());
+	REQUIRE_FALSE(byte.value().second); // Not expecting end-of-packet flag
+	pkt.push_back(byte.value().first);
+      }
+
+      std::vector<uint8_t> pkt_second_half = q.get_pkt();
+      pkt.insert(pkt.end(), pkt_second_half.begin(), pkt_second_half.end());
+
+      // Iterate through the three mode types
+      mode = (mode == FULL_PKT   ? BYTES_ONLY :
+	      mode == BYTES_ONLY ? MIXED      : FULL_PKT);
+    }
+
+    REQUIRE(pkt == packets[i]);
+  }
+
+  REQUIRE(q.empty());
+  REQUIRE(q.size() == 0);
+}

--- a/test/cpp/test_uvvm_cosim_data.cpp
+++ b/test/cpp/test_uvvm_cosim_data.cpp
@@ -18,11 +18,11 @@ std::vector<VvcInstanceKey> vk = {
 
 // Some random imaginary config values pairs
 std::vector<VvcConfig> vc = {
-  VvcConfig{.bfm_cfg = {{"cfg_val1", 0}, {"cfg_val2", 1}, {"cfg_val3", 10}}, .listen_enable=true},
-  VvcConfig{.bfm_cfg = {{"airplane", 200}, {"helicopter", 123}}, .listen_enable=false},
-  VvcConfig{.bfm_cfg = {{"spaghetti", 1}, {"pizza", 234}, {"lasagne", 0}, {"risotto", 89}}, .listen_enable=false},
-  VvcConfig{.bfm_cfg = {{"cookie", 14}}, .listen_enable=true},
-  VvcConfig{.bfm_cfg = {{"firetruck", 123}, {"boat", 23}, {"submarine", 10}}, .listen_enable=false}
+  VvcConfig{.listen_enable=true, .bfm_cfg = {{"cfg_val1", 0}, {"cfg_val2", 1}, {"cfg_val3", 10}}},
+  VvcConfig{.listen_enable=false, .bfm_cfg = {{"airplane", 200}, {"helicopter", 123}}},
+  VvcConfig{.listen_enable=false, .bfm_cfg = {{"spaghetti", 1}, {"pizza", 234}, {"lasagne", 0}, {"risotto", 89}}},
+  VvcConfig{.listen_enable=true, .bfm_cfg = {{"cookie", 14}}},
+  VvcConfig{.listen_enable=false, .bfm_cfg = {{"firetruck", 123}, {"boat", 23}, {"submarine", 10}}}
 };
 
 // Some VVC instances key+config data. GetVvcList returns VvcInstance.
@@ -307,4 +307,13 @@ TEST_CASE("UvvmCosimData_byte_queues")
 TEST_CASE("UvvmCosimData_packet_queues")
 {
   INFO("TODO: Not implemented yet");
+}
+
+TEST_CASE("UvvmCosimData_packet_based_queue_access")
+{
+  INFO("TODO: Not implemented yet");
+
+  // Check that only packet queue methods can be used for
+  // VVCs with packet_based flag set, and only byte queue
+  // methods for those without the flag.
 }

--- a/test/cpp/test_uvvm_cosim_types.cpp
+++ b/test/cpp/test_uvvm_cosim_types.cpp
@@ -17,11 +17,11 @@ std::vector<VvcInstanceKey> vk = {
 
 // Some random imaginary config values pairs
 std::vector<VvcConfig> vc = {
-  VvcConfig{.bfm_cfg = {{"cfg_val1", 0}, {"cfg_val2", 1}, {"cfg_val3", 10}}, .listen_enable=true},
-  VvcConfig{.bfm_cfg = {{"airplane", 200}, {"helicopter", 123}}, .listen_enable=false},
-  VvcConfig{.bfm_cfg = {{"spaghetti", 1}, {"pizza", 234}, {"lasagne", 0}, {"risotto", 89}}, .listen_enable=false},
-  VvcConfig{.bfm_cfg = {{"cookie", 14}}, .listen_enable=true},
-  VvcConfig{.bfm_cfg = {{"firetruck", 123}, {"boat", 23}, {"submarine", 10}}, .listen_enable=false}
+  VvcConfig{.listen_enable=true, .bfm_cfg = {{"cfg_val1", 0}, {"cfg_val2", 1}, {"cfg_val3", 10}}},
+  VvcConfig{.listen_enable=false, .bfm_cfg = {{"airplane", 200}, {"helicopter", 123}}},
+  VvcConfig{.listen_enable=false, .bfm_cfg = {{"spaghetti", 1}, {"pizza", 234}, {"lasagne", 0}, {"risotto", 89}}},
+  VvcConfig{.listen_enable=true, .bfm_cfg = {{"cookie", 14}}},
+  VvcConfig{.listen_enable=false, .bfm_cfg = {{"firetruck", 123}, {"boat", 23}, {"submarine", 10}}}
 };
 
 // Some VVC instances key+config data. Used to test to/from JSON.


### PR DESCRIPTION
Support for packet-based VVCs using the JSON-RPC methods `TransmitPacket` and `ReceivePacket`.
Only implemented for AXI-Stream VVCs at the moment, which can now be configured with `bfm_config.check_packet_length := true` (ie. use the TLAST signal and send full packets).
 